### PR TITLE
Show stats when run `rspack build`

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -24,4 +24,5 @@ module.exports = {
     ],
   },
   plugins: [new CopyPlugin([{ from: "public" }])],
+  stats: "normal",
 };


### PR DESCRIPTION
Before:
```
Time: 4321ms
```

After:
```
Hash: 25212a42dae56f77
Time: 5432ms
PublicPath: auto
                    Asset       Size  Chunks             Chunk Names
 main.460320b323fa647d.js    854 KiB    main  [emitted]  main
              logo512.png   9.44 KiB          [emitted]
              logo192.png   5.22 KiB          [emitted]
              favicon.ico   3.08 KiB          [emitted]
               index.html   1.65 KiB          [emitted]
            manifest.json  518 bytes          [emitted]
main.337e65dc1389f8a4.css  229 bytes    main  [emitted]  main
               robots.txt   67 bytes          [emitted]
Entrypoint main = main.337e65dc1389f8a4.css main.460320b323fa647d.js
[86678] ./src/App.tsx 1.03 KiB {main}
[20054] ./src/index.css 1 bytes {main}
[37013] ./src/index.tsx 279 bytes {main}
[67057] ./node_modules/url/url.js 22.8 KiB {main}
[99075] ./node_modules/url/util.js 314 bytes {main}
[33602] ./src/utils/linear-scale.ts 788 bytes {main}
[24237] ./node_modules/react/index.js 190 bytes {main}
[22590] ./src/components/Dropzone.tsx 488 bytes {main}
[62052] ./src/components/PIXILine.tsx 999 bytes {main}
[86725] ./node_modules/colord/index.mjs 5.73 KiB {main}
[78312] ./src/contexts/PIXIContainer.ts 259 bytes {main}
[8619] ./node_modules/react-is/index.js 196 bytes {main}
[56866] ./src/components/CSVUploader.tsx 1.12 KiB {main}
[51317] ./src/components/Candlestick.tsx 2.65 KiB {main}
[91826] ./src/components/LabelPicker.tsx 1.06 KiB {main}
    + 859 hidden modules
```