### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   eslint:
     name: ESLint


### PR DESCRIPTION
Potential fix for [https://github.com/GarrisonD/financial-time-series-labeler/security/code-scanning/5](https://github.com/GarrisonD/financial-time-series-labeler/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only involves linting and building code, it does not require write permissions. The minimal required permission is `contents: read`, which allows the workflow to access the repository's contents without granting write access. This change will apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
