### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
-    
+
     permissions:
       contents: read
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
+    
     permissions:
       contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/GarrisonD/financial-time-series-labeler/security/code-scanning/2](https://github.com/GarrisonD/financial-time-series-labeler/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `test` job, explicitly setting `contents: read`. This ensures that the job only has read access to the repository contents, which is sufficient for running tests. No other permissions are required for this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
