### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,14 @@ on:
   pull_request:
     paths: [package-lock.json]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
+    
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/GarrisonD/financial-time-series-labeler/security/code-scanning/4](https://github.com/GarrisonD/financial-time-series-labeler/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only requires read access to the repository contents (e.g., for installing dependencies and building the project), we will set `contents: read` at the job level. This ensures that the `GITHUB_TOKEN` has the minimal permissions necessary to execute the workflow.

The `permissions` block will be added under the `test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
